### PR TITLE
fix csv upload error message when salesForceId is already registered

### DIFF
--- a/member-service/src/main/java/org/orcid/member/upload/impl/MemberCsvReader.java
+++ b/member-service/src/main/java/org/orcid/member/upload/impl/MemberCsvReader.java
@@ -4,22 +4,28 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.time.Instant;
+import java.util.Optional;
 
 import io.micrometer.core.instrument.util.StringUtils;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
 import org.orcid.member.domain.Member;
+import org.orcid.member.repository.MemberRepository;
 import org.orcid.member.upload.MemberUpload;
 import org.orcid.member.upload.MembersUploadReader;
 import org.orcid.member.web.rest.MemberValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MemberCsvReader implements MembersUploadReader {
 
 	private static final Logger LOG = LoggerFactory.getLogger(MemberCsvReader.class);
+
+    @Autowired
+    private MemberRepository memberRepository;
 
 	@Override
 	public MemberUpload readMemberUpload(InputStream inputStream) {
@@ -88,7 +94,11 @@ public class MemberCsvReader implements MembersUploadReader {
 		member.setIsConsortiumLead(isConsortiumLead);
 
 		if (validateField(record, "salesforceId", "Salesforce id should not be empty", member)) {
-            member.setSalesforceId(record.get("salesforceId"));
+		    if (memberExists(record.get("salesforceId"))) {
+                member.setError("Member with salesForceId already exist: " + record.get("salesforceId"));
+            } else {
+                member.setSalesforceId(record.get("salesforceId"));
+            }
         }
 
 		if (!isConsortiumLead) {
@@ -115,6 +125,11 @@ public class MemberCsvReader implements MembersUploadReader {
             return false;
         }
         return true;
+    }
+
+    public Boolean memberExists(String salesforceId) {
+        Optional<Member> existingMember = memberRepository.findBySalesforceId(salesforceId);
+        return existingMember.isPresent();
     }
 
 }

--- a/member-service/src/main/java/org/orcid/member/upload/impl/MemberCsvReader.java
+++ b/member-service/src/main/java/org/orcid/member/upload/impl/MemberCsvReader.java
@@ -27,6 +27,10 @@ public class MemberCsvReader implements MembersUploadReader {
     @Autowired
     private MemberRepository memberRepository;
 
+    MemberCsvReader(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
 	@Override
 	public MemberUpload readMemberUpload(InputStream inputStream) {
 		Instant now = Instant.now();

--- a/member-service/src/test/java/org/orcid/member/upload/impl/MemberCsvReaderTest.java
+++ b/member-service/src/test/java/org/orcid/member/upload/impl/MemberCsvReaderTest.java
@@ -6,18 +6,36 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.orcid.member.repository.MemberRepository;
 import org.orcid.member.upload.MemberUpload;
 import org.orcid.member.domain.Member;
 
 class MemberCsvReaderTest {
 
-	private MemberCsvReader reader = new MemberCsvReader();
+    @Mock
+    MemberRepository memberRepository;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    private MemberCsvReader reader = null;
 
 	@Test
 	void testReadMembersUpload() throws IOException {
-		InputStream inputStream = getClass().getResourceAsStream("/members.csv");
+        reader = new MemberCsvReader(memberRepository);
+
+        Mockito.when(memberRepository.findBySalesforceId(Mockito.anyString())).thenReturn(Optional.empty());
+
+        InputStream inputStream = getClass().getResourceAsStream("/members.csv");
 		MemberUpload upload = reader.readMemberUpload(inputStream);
 
 		assertEquals(2, upload.getMembers().size());


### PR DESCRIPTION
https://trello.com/c/e0evY2BG/194-importing-members-via-csv-containing-a-member-that-already-exists-results-in-invalid-id-error