### PR TITLE
fix display assertion role/title

### DIFF
--- a/gateway/src/main/webapp/app/entities/AssertionService/assertion/assertion.component.html
+++ b/gateway/src/main/webapp/app/entities/AssertionService/assertion/assertion.component.html
@@ -55,7 +55,7 @@
                 <td>
                     <span jhiTranslate="{{'gatewayApp.AffiliationSection.' + assertion.affiliationSection}}">{{assertion.affiliationSection}}</span><br>
                     {{assertion.orgName}}: <span *ngIf="assertion.orgCity">{{assertion.orgCity}}</span><span *ngIf="assertion.orgRegion">, {{assertion.orgRegion}}</span><span *ngIf="assertion.orgCountry">, {{assertion.orgCountry}}</span><br>
-                    <span *ngIf="assertion.departmentName">{{assertion.departmentName}}</span><span *ngIf="assertion.departmentName"> ({{assertion.roleTitle}})</span><br>
+                    <span *ngIf="assertion.departmentName">{{assertion.departmentName}}</span><span *ngIf="assertion.roleTitle"> ({{assertion.roleTitle}})</span><br>
                     <span *ngIf="assertion.startYear">{{assertion.startYear}}</span><span *ngIf="assertion.startMonth">-{{assertion.startMonth}}</span><span *ngIf="assertion.startDay">-{{assertion.startDay}}</span>
                     <span *ngIf="assertion.startYear && assertion.endYear">&nbsp;to&nbsp;</span>
                     <span *ngIf="assertion.endYear">{{assertion.endYear}}</span><span *ngIf="assertion.endMonth">-{{assertion.endMonth}}</span><span *ngIf="assertion.endDay">-{{assertion.endDay}} </span>


### PR DESCRIPTION
https://trello.com/c/yFP8ZD7w/211-affiliation-role-title-is-not-displayed-in-assertion-if-there-is-no-department-name