### PR TITLE
fix error message in member when a salesforceId already exists

### DIFF
--- a/gateway/src/main/webapp/i18n/en/error.json
+++ b/gateway/src/main/webapp/i18n/en/error.json
@@ -22,6 +22,8 @@
     "memberNotFound": "Member not found with salesForceId: {{ params }} ",
     "salesForceIdUsed": "A member with that salesforce id already exists",
     "affiliationOtherOrganization": "This affiliations doesnt belong to your organization",
-    "emailAffiliationUsed": "Unable to add affiliation. An affiliation for {{ params }} already exists and belongs to another organization."
+    "emailAffiliationUsed": "Unable to add affiliation. An affiliation for {{ params }} already exists and belongs to another organization.",
+    "affiliationOtherOrganization": "This affiliations doesnt belong to your organization",
+    "memberNameUsed": "A member with that name already exists"
   }
 }

--- a/gateway/src/main/webapp/i18n/es/error.json
+++ b/gateway/src/main/webapp/i18n/es/error.json
@@ -20,6 +20,7 @@
     "memberNotFound": "Miembro no encontrado con salesForceId: {{ params }} ",
     "salesForceIdUsed": "Un miembro con ese salesforce id ya existe",
     "affiliationOtherOrganization": "Esta afiliacion no pertenece a tu organizacion",
-    "emailAffiliationUsed": "No fue posible agregar la afiliacion. Una afiliacion con {{ params }} ya existe y pertenece a otra organizacion."
+    "emailAffiliationUsed": "No fue posible agregar la afiliacion. Una afiliacion con {{ params }} ya existe y pertenece a otra organizacion.",
+    "memberNameUsed": "Un miembro con ese nombre ya existe"
   }
 }

--- a/member-service/src/main/java/org/orcid/member/repository/MemberRepository.java
+++ b/member-service/src/main/java/org/orcid/member/repository/MemberRepository.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Repository;
 public interface MemberRepository extends MongoRepository<Member, String> {
 	
     Optional<Member> findBySalesforceId(String salesforceId);
-    
+
+    Optional<Member> findByClientName(String salesforceId);
+
     Boolean existsBySalesforceId(String salesforceId);
 }


### PR DESCRIPTION
https://trello.com/c/3PYeBBes/250-error-message-when-trying-to-update-a-member-with-a-salesforceid-that-already-exists-in-the-portal