### PR TITLE
fix testPostAssertion test

### DIFF
--- a/assertion-service/src/main/java/org/orcid/repository/AssertionsRepositoryCustom.java
+++ b/assertion-service/src/main/java/org/orcid/repository/AssertionsRepositoryCustom.java
@@ -3,9 +3,11 @@ package org.orcid.repository;
 import java.util.List;
 
 import org.orcid.domain.Assertion;
+import org.springframework.data.mongodb.repository.Query;
 
 public interface AssertionsRepositoryCustom {
-	
-	List<Assertion> findAllToUpdate();
+
+    @Query("{putCode: {$ne:null}}")
+    List<Assertion> findAllToUpdate();
 
 }

--- a/assertion-service/src/main/java/org/orcid/service/AssertionService.java
+++ b/assertion-service/src/main/java/org/orcid/service/AssertionService.java
@@ -364,9 +364,6 @@ public class AssertionService {
                 storeError(assertion.getId(), 0, e.getMessage());
             }
 
-            if (orcid != null && !getAssertionStatus(assertion).equals(AssertionStatus.IN_ORCID.value)) {
-                removeOrcidIdFromOrcidRecord(record);
-            }
         }
     }
 
@@ -496,7 +493,7 @@ public class AssertionService {
         Optional<OrcidRecord> optionalRecord = orcidRecordService.findOneByEmail(assertion.getEmail());
         if (optionalRecord.isPresent()) {
             OrcidRecord record = optionalRecord.get();
-            return !StringUtils.isBlank(record.getToken(assertion.getSalesforceId())) ? record.getOrcid() : null;
+            return record.getOrcid();
         }
         return null;
     }
@@ -553,12 +550,6 @@ public class AssertionService {
 
     public List<Assertion> getAssertionsBySalesforceId(String salesforceId) {
         return assertionsRepository.findBySalesforceId(salesforceId);
-    }
-
-    private void removeOrcidIdFromOrcidRecord(OrcidRecord orcidRecord) {
-        orcidRecord.setOrcid(null);
-        orcidRecord.setModified(Instant.now());
-        orcidRecordService.updateOrcidRecord(orcidRecord);
     }
 
 }

--- a/assertion-service/src/test/java/org/orcid/service/AssertionsServiceTest.java
+++ b/assertion-service/src/test/java/org/orcid/service/AssertionsServiceTest.java
@@ -166,7 +166,7 @@ class AssertionsServiceTest {
 		a = assertionsService.createOrUpdateAssertion(a);
 		assertNotNull(a.getStatus());
 		Mockito.verify(assertionsRepository, Mockito.times(1)).save(Mockito.eq(a));
-		assertNull(a.getOrcidId());
+		assertNotNull(a.getOrcidId());
 
 		b = assertionsService.createOrUpdateAssertion(b);
 		assertNotNull(b.getStatus());
@@ -297,11 +297,11 @@ class AssertionsServiceTest {
 		Mockito.verify(assertionsRepository, Mockito.times(3)).save(Mockito.any(Assertion.class));
 		Mockito.verify(assertionsRepository, Mockito.times(2)).insert(Mockito.any(Assertion.class));
 
-		assertNull(a.getOrcidId());
-		assertNull(b.getOrcidId());
-		assertNull(c.getOrcidId());
-		assertNull(d.getOrcidId());
-		assertNull(e.getOrcidId());
+		assertNotNull(a.getOrcidId());
+        assertNotNull(b.getOrcidId());
+        assertNotNull(c.getOrcidId());
+        assertNotNull(d.getOrcidId());
+        assertNotNull(e.getOrcidId());
 	}
 
 	@Test
@@ -350,7 +350,7 @@ class AssertionsServiceTest {
 
 		assertionsService.createAssertion(a);
 		Mockito.verify(assertionsRepository, Mockito.times(1)).insert(Mockito.eq(a));
-		assertNull(a.getOrcidId());
+		assertNotNull(a.getOrcidId());
 	}
 
 	@Test
@@ -398,7 +398,7 @@ class AssertionsServiceTest {
 		Mockito.when(orcidRecordService.findOneByEmail(Mockito.eq("email"))).thenReturn(getOptionalOrcidRecordWithoutIdToken());
 		a = assertionsService.createOrUpdateAssertion(a);
 		assertNotNull(a.getStatus());
-		assertNull(a.getOrcidId());
+		assertNotNull(a.getOrcidId());
 		Mockito.verify(assertionsRepository, Mockito.times(1)).save(Mockito.eq(a));
 	}
 

--- a/assertion-service/src/test/java/org/orcid/service/AssertionsServiceTest.java
+++ b/assertion-service/src/test/java/org/orcid/service/AssertionsServiceTest.java
@@ -171,7 +171,7 @@ class AssertionsServiceTest {
 		b = assertionsService.createOrUpdateAssertion(b);
 		assertNotNull(b.getStatus());
 		Mockito.verify(assertionsRepository, Mockito.times(1)).insert(Mockito.eq(b));
-		assertNull(b.getOrcidId());
+        assertNotNull(b.getOrcidId());
 	}
 
 	@Test

--- a/assertion-service/src/test/java/org/orcid/service/AssertionsServiceTest.java
+++ b/assertion-service/src/test/java/org/orcid/service/AssertionsServiceTest.java
@@ -467,7 +467,7 @@ class AssertionsServiceTest {
 
 		assertionsService.postAssertionsToOrcid();
 
-		Mockito.verify(orcidRecordService, Mockito.times(25)).findOneByEmail(Mockito.anyString());
+		Mockito.verify(orcidRecordService, Mockito.times(20)).findOneByEmail(Mockito.anyString());
 		//Mockito.verify(orcidAPIClient, Mockito.times(5)).exchangeToken(Mockito.anyString());
 		Mockito.verify(orcidAPIClient, Mockito.times(5)).postAffiliation(Mockito.anyString(), Mockito.anyString(),
 				Mockito.any(Assertion.class));


### PR DESCRIPTION
https://trello.com/c/IKt9SK6O/330-qa-orcid-id-still-removed-from-assertion-after-access-to-the-record-is-revoked