### PR TITLE
adding missing text in signature on organization owner modified email

### DIFF
--- a/user-service/src/main/resources/templates/mail/organizationOwnerChanged.html
+++ b/user-service/src/main/resources/templates/mail/organizationOwnerChanged.html
@@ -55,6 +55,8 @@
         <span th:text="#{email.common.signature}">The ORCID Member Portal Team</span> <br />
         <a href="mailto:membership@orcid.org">membership@orcid.org</a>
     </p>
+    <p th:text="#{email.common.youHaveReceived}">You have received
+        this email as a service announcement related to your ORCID Member Portal account.</p>
     <div th:insert="~{mail/common :: emailFooter}"></div>
 </div>
 </body>


### PR DESCRIPTION
https://trello.com/c/wnFyqoPQ/348-qa-service-announcement-line-missing-from-org-owner-updated-email