### PR TITLE
Deleting assertions no longer checks logged in user's salesforce id, …

### DIFF
--- a/assertion-service/src/main/java/org/orcid/memberportal/service/assertion/web/rest/AssertionServiceResource.java
+++ b/assertion-service/src/main/java/org/orcid/memberportal/service/assertion/web/rest/AssertionServiceResource.java
@@ -179,7 +179,7 @@ public class AssertionServiceResource {
 
     @DeleteMapping("/assertion/{id}")
     public ResponseEntity<String> deleteAssertion(@PathVariable String id) throws BadRequestAlertException {
-        assertionService.deleteById(id);
+        assertionService.deleteById(id, assertionsUserService.getLoggedInUser());
         LOG.info("{} deleted assertion {}", SecurityUtils.getCurrentUserLogin().get(), id);
         return ResponseEntity.ok().body("{\"id\":\"" + id + "\"}");
     }
@@ -231,7 +231,7 @@ public class AssertionServiceResource {
 
     @DeleteMapping("/assertion/orcid/{id}")
     public ResponseEntity<String> deleteAssertionFromOrcid(@PathVariable String id) throws JAXBException {
-        Boolean deleted = assertionService.deleteAssertionFromOrcidRegistry(id);
+        Boolean deleted = assertionService.deleteAssertionFromOrcidRegistry(id, assertionsUserService.getLoggedInUser());
         JSONObject responseData = new JSONObject();
         responseData.put("deleted", deleted);
 

--- a/assertion-service/src/test/java/org/orcid/memberportal/service/assertion/services/AssertionServiceTest.java
+++ b/assertion-service/src/test/java/org/orcid/memberportal/service/assertion/services/AssertionServiceTest.java
@@ -602,7 +602,7 @@ class AssertionServiceTest {
         Mockito.when(orcidRecordService.findOneByEmail("something@orcid.org")).thenReturn(getOptionalOrcidRecordWithIdToken());
         Mockito.when(orcidAPIClient.exchangeToken(Mockito.anyString())).thenReturn("accessToken");
         Mockito.when(orcidAPIClient.deleteAffiliation(Mockito.anyString(), Mockito.eq("accessToken"), Mockito.any(Assertion.class))).thenReturn(true);
-        assertionService.deleteAssertionFromOrcidRegistry("assertionId");
+        assertionService.deleteAssertionFromOrcidRegistry("assertionId", getUser());
 
         Mockito.verify(orcidAPIClient, Mockito.times(1)).exchangeToken(Mockito.anyString());
         Mockito.verify(orcidAPIClient, Mockito.times(1)).deleteAffiliation(Mockito.anyString(), Mockito.anyString(), Mockito.any(Assertion.class));
@@ -620,7 +620,7 @@ class AssertionServiceTest {
         Mockito.when(orcidRecordService.findOneByEmail("something@orcid.org")).thenReturn(getOptionalOrcidRecordWithIdToken());
         Mockito.when(orcidAPIClient.exchangeToken(Mockito.anyString())).thenReturn("accessToken");
         Mockito.when(orcidAPIClient.deleteAffiliation(Mockito.anyString(), Mockito.eq("accessToken"), Mockito.any(Assertion.class))).thenReturn(false);
-        assertionService.deleteAssertionFromOrcidRegistry("assertionId");
+        assertionService.deleteAssertionFromOrcidRegistry("assertionId", getUser());
 
         Mockito.verify(orcidAPIClient, Mockito.times(1)).exchangeToken(Mockito.anyString());
         Mockito.verify(orcidAPIClient, Mockito.times(1)).deleteAffiliation(Mockito.anyString(), Mockito.anyString(), Mockito.any(Assertion.class));
@@ -638,7 +638,7 @@ class AssertionServiceTest {
         Mockito.when(orcidAPIClient.exchangeToken(Mockito.anyString())).thenReturn("accessToken");
         Mockito.doThrow(new ORCIDAPIException(404, "not found")).when(orcidAPIClient).deleteAffiliation(Mockito.anyString(), Mockito.eq("accessToken"),
                 Mockito.any(Assertion.class));
-        assertionService.deleteAssertionFromOrcidRegistry("assertionId");
+        assertionService.deleteAssertionFromOrcidRegistry("assertionId", getUser());
 
         Mockito.verify(orcidAPIClient, Mockito.times(1)).exchangeToken(Mockito.anyString());
         Mockito.verify(orcidAPIClient, Mockito.times(1)).deleteAffiliation(Mockito.anyString(), Mockito.anyString(), Mockito.any(Assertion.class));
@@ -698,7 +698,7 @@ class AssertionServiceTest {
         Mockito.when(orcidRecordService.generateLinkForEmail("test@orcid.org")).thenReturn("don't care");
         Mockito.doNothing().when(assertionsRepository).deleteById(Mockito.eq("id"));
 
-        assertionService.deleteById("id");
+        assertionService.deleteById("id", getUser());
 
         Mockito.verify(assertionsRepository, Mockito.times(1)).deleteById(Mockito.eq("id"));
         Mockito.verify(orcidRecordService, Mockito.never()).deleteOrcidRecord(Mockito.any());
@@ -715,7 +715,7 @@ class AssertionServiceTest {
         Mockito.doNothing().when(orcidRecordService).deleteOrcidRecord(Mockito.any(OrcidRecord.class));
         Mockito.doNothing().when(assertionsRepository).deleteById(Mockito.eq("id"));
 
-        assertionService.deleteById("id");
+        assertionService.deleteById("id", getUser());
 
         Mockito.verify(assertionsRepository, Mockito.times(1)).deleteById(Mockito.eq("id"));
         Mockito.verify(orcidRecordService, Mockito.times(1)).deleteOrcidRecord(Mockito.any());
@@ -776,10 +776,9 @@ class AssertionServiceTest {
         Mockito.when(orcidAPIClient.exchangeToken(Mockito.anyString())).thenReturn("exchange-token");
         Mockito.when(orcidAPIClient.deleteAffiliation(Mockito.anyString(), Mockito.eq("exchange-token"), Mockito.any(Assertion.class))).thenReturn(true);
 
-        assertionService.deleteAssertionFromOrcidRegistry("id");
+        assertionService.deleteAssertionFromOrcidRegistry("id", getUser());
 
         Mockito.verify(assertionsRepository, Mockito.times(1)).findById(Mockito.eq("id"));
-        Mockito.verify(assertionsUserService, Mockito.times(1)).getLoggedInUserSalesforceId();
         Mockito.verify(orcidRecordService, Mockito.atLeastOnce()).findOneByEmail(Mockito.eq("test@email.com"));
         Mockito.verify(orcidAPIClient, Mockito.times(1)).exchangeToken(Mockito.anyString());
         Mockito.verify(orcidAPIClient, Mockito.times(1)).deleteAffiliation(Mockito.anyString(), Mockito.eq("exchange-token"), Mockito.any(Assertion.class));
@@ -792,8 +791,10 @@ class AssertionServiceTest {
         Mockito.when(assertionsRepository.findById(Mockito.eq("id"))).thenReturn(Optional.of(assertion));
         Mockito.when(assertionsUserService.getLoggedInUserSalesforceId()).thenReturn("wrong-salesforce-id");
 
+        AssertionServiceUser user = getUser();
+        user.setSalesforceId("something-wrong");
         Assertions.assertThrows(BadRequestAlertException.class, () -> {
-            assertionService.deleteAssertionFromOrcidRegistry("id");
+            assertionService.deleteAssertionFromOrcidRegistry("id", user);
         });
     }
 
@@ -806,10 +807,9 @@ class AssertionServiceTest {
         Mockito.when(assertionsUserService.getLoggedInUserSalesforceId()).thenReturn("salesforce-id");
         Mockito.when(orcidRecordService.findOneByEmail(Mockito.eq("test@email.com"))).thenReturn(getOptionalOrcidRecordWithoutIdToken());
 
-        assertionService.deleteAssertionFromOrcidRegistry("id");
+        assertionService.deleteAssertionFromOrcidRegistry("id", getUser());
 
         Mockito.verify(assertionsRepository, Mockito.times(1)).findById(Mockito.eq("id"));
-        Mockito.verify(assertionsUserService, Mockito.times(1)).getLoggedInUserSalesforceId();
         Mockito.verify(orcidRecordService, Mockito.atLeastOnce()).findOneByEmail(Mockito.eq("test@email.com"));
         Mockito.verify(orcidAPIClient, Mockito.never()).exchangeToken(Mockito.anyString());
         Mockito.verify(orcidAPIClient, Mockito.never()).deleteAffiliation(Mockito.anyString(), Mockito.eq("exchange-token"), Mockito.any(Assertion.class));

--- a/assertion-service/src/test/java/org/orcid/memberportal/service/assertion/web/rest/AssertionServiceResourceTest.java
+++ b/assertion-service/src/test/java/org/orcid/memberportal/service/assertion/web/rest/AssertionServiceResourceTest.java
@@ -104,7 +104,7 @@ class AssertionServiceResourceTest {
 
     @Test
     void testDeleteAssertionFromOrcidSuccessful() throws JSONException, JAXBException {
-        Mockito.when(assertionService.deleteAssertionFromOrcidRegistry(Mockito.eq("assertionId"))).thenReturn(Boolean.TRUE);
+        Mockito.when(assertionService.deleteAssertionFromOrcidRegistry(Mockito.eq("assertionId"), Mockito.any(AssertionServiceUser.class))).thenReturn(Boolean.TRUE);
         ResponseEntity<String> response = assertionServiceResource.deleteAssertionFromOrcid("assertionId");
         String body = response.getBody();
         assertEquals("{\"deleted\":true}", body);
@@ -112,7 +112,7 @@ class AssertionServiceResourceTest {
 
     @Test
     void testDeleteAssertionFromOrcidFailure() throws JSONException, JAXBException {
-        Mockito.when(assertionService.deleteAssertionFromOrcidRegistry(Mockito.eq("assertionId"))).thenReturn(Boolean.FALSE);
+        Mockito.when(assertionService.deleteAssertionFromOrcidRegistry(Mockito.eq("assertionId"), Mockito.any(AssertionServiceUser.class))).thenReturn(Boolean.FALSE);
         Mockito.when(assertionService.findById(Mockito.eq("assertionId"))).thenReturn(getAssertionWithError());
         ResponseEntity<String> response = assertionServiceResource.deleteAssertionFromOrcid("assertionId");
         String body = response.getBody();


### PR DESCRIPTION
…user taken as param instead due to backend csv processing