### PR TITLE
adding fix for angular route refresh problem

### DIFF
--- a/ui/container-files/etc/nginx/conf.d/default.conf
+++ b/ui/container-files/etc/nginx/conf.d/default.conf
@@ -7,7 +7,8 @@ server {
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
-	rewrite  ^/ui/(.*) /$1 break;
+	    rewrite  ^/ui/(.*) /$1 break;
+        try_files $uri $uri/ /index.html;
     }
 
     # JT. Uncomment the error_page directive below to use the orcid 404 error page in /404


### PR DESCRIPTION
Attempting to browse /ui/login will result in a 404 error.
This change will configure a fallback route in the NGinX server to serve the index.html file when a route is not matched