### PR TITLE
fix: remove null observable from navbar

### DIFF
--- a/ui-2/src/app/layout/navbar/navbar.component.spec.ts
+++ b/ui-2/src/app/layout/navbar/navbar.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing'
 import { ReactiveFormsModule } from '@angular/forms'
 import { By } from '@angular/platform-browser'
-import { of } from 'rxjs'
+import { BehaviorSubject, of } from 'rxjs'
 import { AccountService, LoginService } from 'src/app/account'
 import { MemberService } from 'src/app/member/service/member.service'
 import { HasAnyAuthorityDirective } from 'src/app/shared/directive/has-any-authority.directive'
@@ -43,6 +43,7 @@ describe('NavbarComponent', () => {
       'getMemberId',
     ])
     accountServiceSpy.getAccountData.and.returnValue(of(null))
+    ;(accountServiceSpy as any).accountData = new BehaviorSubject(null)
     const modalServiceSpy = jasmine.createSpyObj('NgbModal', ['open'])
     const mockOidcSecurityService = {
       checkAuth: () => of({ isAuthenticated: true, userData: { email: 'test@email.com' } }),

--- a/ui-2/src/app/layout/navbar/navbar.component.ts
+++ b/ui-2/src/app/layout/navbar/navbar.component.ts
@@ -18,7 +18,6 @@ import {
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
 import { NgbDropdown, NgbDropdownMenu, NgbDropdownToggle } from '@ng-bootstrap/ng-bootstrap/dropdown'
 import { OidcSecurityService } from 'angular-auth-oidc-client'
-import { of } from 'rxjs'
 import { IMember } from 'src/app/member/model/member.model'
 import { MemberService } from 'src/app/member/service/member.service'
 import { FeatureToggleService } from 'src/app/shared/service/feature-toggle.service'
@@ -79,13 +78,10 @@ export class NavbarComponent {
   protected faKey = faKey
 
   constructor() {
-    const oidcAuthState$ = (this.oidcSecurityService as any).isAuthenticated$ ?? of({ isAuthenticated: false })
-    const accountData$ = this.accountService.getAccountData() ?? of(null)
 
-    oidcAuthState$
+    this.oidcSecurityService.isAuthenticated$
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((authState: any) => {
-        const isAuthenticated = !!authState?.isAuthenticated
+      .subscribe(({ isAuthenticated }) => {
         this.isUserAuthenticated.set(isAuthenticated)
         if (isAuthenticated) {
           this.updateAuthenticationState()
@@ -95,7 +91,7 @@ export class NavbarComponent {
         }
       })
 
-    accountData$
+    this.accountService.accountData.asObservable()
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((account) => {
         if (account) {


### PR DESCRIPTION
Commit d9f91ddb introduced an infinite redirect loop on the login page. It changed the navbar constructor to call this.accountService.getAccountData() instead of subscribing directly to this.accountService.accountData.asObservable().

getAccountData() triggers an HTTP fetch to /userservice/account on every page — including /login. When a stale OIDC token is present in storage:

Navbar initializes on /login → getAccountData() → GET /userservice/account → 401
AuthExpiredInterceptor detects 401 + token → calls loginService.logout()
clearAccountData() → router.navigate(['/login'])
Navbar re-initializes → back to step 1 → ∞
Fix

Revert to subscribing directly to the BehaviorSubject (accountData.asObservable()), which carries no side effects. The actual fetch is already initiated by AppComponent.ngOnInit

https://orcid.clickup.com/t/9014437828/PD-5874