### PR TITLE
fix: switch OIDC security storage to local storage so auth state is shared across new tab

### DIFF
--- a/ui-2/src/app/app.module.ts
+++ b/ui-2/src/app/app.module.ts
@@ -4,7 +4,7 @@ import { BrowserModule } from '@angular/platform-browser'
 import { CommonModule } from '@angular/common'
 import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
 import { FormsModule } from '@angular/forms'
-import { AuthInterceptor, AuthModule, LogLevel } from 'angular-auth-oidc-client'
+import { AbstractSecurityStorage, AuthInterceptor, AuthModule, DefaultLocalStorageService, LogLevel } from 'angular-auth-oidc-client'
 import { QuillModule } from 'ngx-quill'
 import { provideNgxWebstorage, withLocalStorage, withNgxWebstorageConfig, withSessionStorage } from 'ngx-webstorage'
 import { environment } from '../environments/environment'
@@ -50,6 +50,10 @@ import { ApiCredentialsMfaEnabledDialogComponent } from './layout/navbar/api-cre
       provide: HTTP_INTERCEPTORS,
       useClass: AuthInterceptor,
       multi: true,
+    },
+    {
+      provide: AbstractSecurityStorage,
+      useClass: DefaultLocalStorageService,
     },
     {
       provide: HTTP_INTERCEPTORS,


### PR DESCRIPTION
Problem:
Opening View details via right-click → Open link in new tab prompted users to log in again, even if they were already authenticated in the original tab.

Root cause:
OIDC auth state was being stored in session storage, which is tab-scoped. A new tab did not have the existing auth state.

Fix:
Switched OIDC security storage to local storage so auth state is shared across tabs on the same origin.

https://orcid.clickup.com/t/9014437828/PD-5875