### PR TITLE
fix: save button unavailable when checking `Organization Owner`

### DIFF
--- a/ui-2/src/app/user/user-update.component.html
+++ b/ui-2/src/app/user/user-update.component.html
@@ -98,7 +98,7 @@
           >
           <fieldset [disabled]="isExistentMember()">
             @if (memberList().length > 0) {
-              <select class="form-select" name="memberId" id="field_memberId" formControlName="memberId">
+              <select class="form-select mb-3" name="memberId" id="field_memberId" formControlName="memberId">
                 @for (member of memberList(); track member) {
                   <option [ngValue]="member.id">{{ member.clientName }}</option>
                 }

--- a/ui-2/src/app/user/user-update.component.ts
+++ b/ui-2/src/app/user/user-update.component.ts
@@ -14,7 +14,7 @@ import { faBan, faCheckCircle, faSave } from '@fortawesome/free-solid-svg-icons'
 import moment from 'moment'
 import { Observable } from 'rxjs'
 
-import { map } from 'rxjs/operators'
+import { map, finalize } from 'rxjs/operators'
 import { AccountService } from '../account'
 import { IAccount } from '../account/model/account.model'
 import { AlertMessage, AlertType, DATE_TIME_FORMAT, emailValidator } from '../app.constants'
@@ -239,14 +239,18 @@ export class UserUpdateComponent implements OnInit {
     this.isSaving.set(true)
     const memberId = this.editForm.get('memberId')?.value
     if (memberId) {
-      this.userService.hasOwner(memberId).subscribe((value) => {
-        this.isSaving.set(false)
+      this.userService.hasOwner(memberId).pipe(
+        finalize(() => this.isSaving.set(false))
+      ).subscribe((value) => {
         if (!this.editForm.get('mainContact')?.value) {
           this.hasOwner.set(false)
         } else {
           this.hasOwner.set(value)
         }
       })
+    } else {
+      this.isSaving.set(false)
+      this.hasOwner.set(false)
     }
     if (event) {
       const checked = (event.target as HTMLInputElement).checked


### PR DESCRIPTION
Fix 1: Save button unavailable when checking "Organization Owner"

Fixed a bug in the validateOrgOwners() method where the isSaving flag was not being reset in all cases. When users checked the "Organization Owner" checkbox, isSaving was set to true, but if the organization (memberId) wasn't yet selected, the flag was never reset to false, leaving the Save button permanently disabled.

Solution: Added the finalize RxJS operator to ensure isSaving is always reset when the subscription completes, regardless of success or failure. Also added an else branch to handle the case when memberId is not set.

https://orcid.clickup.com/t/9014437828/PD-5923