### PR TITLE
feat(user-service): add activation email v2 behind ACTIVATION_EMAIL_V…

### DIFF
--- a/user-service-2/src/main/java/org/orcid/mp/user/config/togglz/PortalFeatures.java
+++ b/user-service-2/src/main/java/org/orcid/mp/user/config/togglz/PortalFeatures.java
@@ -11,7 +11,10 @@ import org.togglz.core.context.FeatureContext;
 public enum PortalFeatures implements Feature {
 
     @Label("Manage API credentials")
-    MANAGE_API_CREDENTIALS;
+    MANAGE_API_CREDENTIALS,
+
+    @Label("Activation email v2")
+    ACTIVATION_EMAIL_V2;
 
     public boolean isActive() {
         return FeatureContext.getFeatureManager().isActive(this);

--- a/user-service-2/src/main/java/org/orcid/mp/user/service/MailService.java
+++ b/user-service-2/src/main/java/org/orcid/mp/user/service/MailService.java
@@ -57,7 +57,11 @@ public class MailService {
 
     public void sendActivationEmail(User user) {
         LOGGER.debug("Sending activation email to '{}'", user.getEmail());
-        sendEmailFromTemplate(user, "mail/activationEmail", "email.activation.title");
+        if (PortalFeatures.ACTIVATION_EMAIL_V2.isActive()) {
+            sendEmailFromTemplate(user, "mail/activationEmail_v2", "email.activationv2.title");
+        } else {
+            sendEmailFromTemplate(user, "mail/activationEmail", "email.activation.title");
+        }
     }
 
     public void sendPasswordResetMail(User user) {

--- a/user-service-2/src/main/resources/i18n/messages.properties
+++ b/user-service-2/src/main/resources/i18n/messages.properties
@@ -12,6 +12,13 @@ email.common.warmRegards=Warm Regards,
 email.common.youHaveReceived=You have received this email as a service announcement related to your ORCID Member Portal account.
 # Activation email
 email.activation.title=ORCID Member Portal activation
+# Activation email v2
+email.activationv2.title=ORCID Member Portal Activation
+email.activationv2.link1.text=ORCID Member Portal
+email.activationv2.text1=As part of your ORCID membership you have access to the\u0020
+email.activationv2.text2=After you have activated your account you will be able to maintain your organization's membership information, access member reports plus managing affiliation uploads and Member API credentials depending on your account settings.
+email.activationv2.text3=Please click on the link below to activate your account:
+email.activationv2.text4=If you have any problems activating your account then please contact our Member Support Team.
 # Creation email
 email.creation.title=Welcome to the ORCID Member Portal
 email.creation.text1=As part of your organization's ORCID membership you have access to the\u0020

--- a/user-service-2/src/main/resources/i18n/messages_en.properties
+++ b/user-service-2/src/main/resources/i18n/messages_en.properties
@@ -12,6 +12,13 @@ email.common.warmRegards=Warm Regards,
 email.common.youHaveReceived=You have received this email as a service announcement related to your ORCID Member Portal account.
 # Activation email
 email.activation.title=ORCID Member Portal activation
+# Activation email v2
+email.activationv2.title=ORCID Member Portal Activation
+email.activationv2.link1.text=ORCID Member Portal
+email.activationv2.text1=As part of your ORCID membership you have access to the\u0020
+email.activationv2.text2=After you have activated your account you will be able to maintain your organization's membership information, access member reports plus managing affiliation uploads and Member API credentials depending on your account settings.
+email.activationv2.text3=Please click on the link below to activate your account:
+email.activationv2.text4=If you have any problems activating your account then please contact our Member Support Team.
 # Creation email
 email.creation.title=Welcome to the ORCID Member Portal
 email.creation.text1=As part of your organization's ORCID membership you have access to the\u0020

--- a/user-service-2/src/main/resources/templates/mail/activationEmail_v2.html
+++ b/user-service-2/src/main/resources/templates/mail/activationEmail_v2.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title th:text="#{email.activationv2.title}">ORCID Member Portal Activation</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <link rel="shortcut icon" th:href="@{|${baseUrl}/favicon.ico|}"/>
+</head>
+<body
+        style="font-family: arial, helvetica, sans-serif; font-size: 15px; color: #494A4C;">
+<div style="padding: 20px; padding-top: 10px; margin: auto;">
+    <div th:insert="~{mail/common :: emailHeader}"></div>
+    <p>
+        <span th:text="#{email.activationv2.text1}">As part of your ORCID membership you have access to the </span><a
+            href="https://info.orcid.org/documentation/member-portal/" th:text="#{email.activationv2.link1.text}">ORCID
+        Member Portal</a><span>.</span>
+    </p>
+    <p>
+        <span th:text="#{email.activationv2.text2}">After you have activated your account you will be able to maintain your organization's membership information, access member reports plus managing affiliation uploads and Member API credentials depending on your account settings.</span>
+    </p>
+    <p>
+        <span th:text="#{email.activationv2.text3}">Please click on the link below to activate your account:</span>
+    </p>
+    <p>
+        <a style="color: #2E7F9F;" th:with="url=(@{|${baseUrl}/${user.langKey}/reset/finish?key=${user.resetKey}|})"
+           th:href="${url}" th:text="${url}">Login link</a>
+    </p>
+    <p>
+        <span th:text="#{email.activationv2.text4}">If you have any problems activating your account then please contact our Member Support Team.</span>
+    </p>
+    <p>
+        <span th:text="#{email.common.warmRegards}">Warm Regards,</span> <br/>
+        <span th:text="#{email.common.signature}">The ORCID Member Portal Team</span> <br/>
+        <a style="color: #2E7F9F;" href="mailto:membership@orcid.org">membership@orcid.org</a>
+    </p>
+    <p th:text="#{email.common.youHaveReceived}">You have received this email as a service announcement related to your ORCID Member Portal account.</p>
+    <div th:insert="~{mail/common :: emailFooter}"></div>
+</div>
+</body>
+</html>

--- a/user-service-2/src/test/java/org/orcid/mp/user/service/MailServiceIT.java
+++ b/user-service-2/src/test/java/org/orcid/mp/user/service/MailServiceIT.java
@@ -3,6 +3,9 @@ package org.orcid.mp.user.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
+import org.orcid.mp.user.config.togglz.PortalFeatures;
+import org.togglz.testing.TestFeatureManager;
+import org.togglz.testing.TestFeatureManagerProvider;
 import org.orcid.mp.user.UserServiceApplication;
 import org.orcid.mp.user.client.MailgunClient;
 import org.orcid.mp.user.config.Constants;
@@ -42,11 +45,16 @@ public class MailServiceIT {
 
     private MailService mailService;
 
+    private TestFeatureManager featureManager;
+
     @BeforeEach
     public void setup() throws MailException {
         MockitoAnnotations.initMocks(this);
         doNothing().when(mailgunClient).sendMail(anyString(), anyString(), anyString());
         mailService = new MailService(messageSource, templateEngine, mailgunClient);
+        featureManager = new TestFeatureManager(PortalFeatures.class);
+        featureManager.disableAll();
+        TestFeatureManagerProvider.setFeatureManager(featureManager);
     }
 
     @Test
@@ -58,6 +66,19 @@ public class MailServiceIT {
         verify(mailgunClient, Mockito.times(1)).sendMail(recipientCaptor.capture(), subjectCaptor.capture(), contentCaptor.capture());
         assertThat(recipientCaptor.getValue()).isEqualTo("john.doe@example.com");
         assertThat(subjectCaptor.getValue()).isEqualTo("ORCID Member Portal activation");
+        assertThat(contentCaptor.getValue()).isNotNull();
+    }
+
+    @Test
+    public void testSendActivationEmailV2() throws Exception {
+        featureManager.enable(PortalFeatures.ACTIVATION_EMAIL_V2);
+        User user = new User();
+        user.setLangKey(Constants.DEFAULT_LANGUAGE);
+        user.setEmail("john.doe@example.com");
+        mailService.sendActivationEmail(user);
+        verify(mailgunClient, Mockito.times(1)).sendMail(recipientCaptor.capture(), subjectCaptor.capture(), contentCaptor.capture());
+        assertThat(recipientCaptor.getValue()).isEqualTo("john.doe@example.com");
+        assertThat(subjectCaptor.getValue()).isEqualTo("ORCID Member Portal Activation");
         assertThat(contentCaptor.getValue()).isNotNull();
     }
 


### PR DESCRIPTION
…2 feature toggle

Add a new version of the account activation email reflecting the current capabilities of the ORCID Member Portal, selectable at runtime via the existing Togglz console without touching the original email.

Changes:
- PortalFeatures: add ACTIVATION_EMAIL_V2 enum constant (off by default)
- MailService.sendActivationEmail: branch on ACTIVATION_EMAIL_V2.isActive() to serve activationEmail_v2 or the original activationEmail template
- activationEmail_v2.html: new Thymeleaf template with updated copy:
    - updated description paragraph covering membership info, member reports, affiliation uploads, and Member API credentials
    - same activation-link generation and shared header/footer fragments as v1
- messages.properties / messages_en.properties: add email.activationv2.* keys (title, link text, four body paragraphs); other locales fall back to the base properties file as per existing convention
- MailServiceIT: initialise TestFeatureManager in @BeforeEach (all features disabled), keeping the v1 test unchanged; add testSendActivationEmailV2 which enables the flag and asserts the new subject  
- 
- https://orcid.clickup.com/t/9014437828/PD-5939