### PR TITLE
PD-12930 Move the local dev ports off 9000 and 4200

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       dockerfile: ./src/main/docker/Dockerfile
     image: ${DOCKER_REG}/userservice2:${TAG}
     ports:
-      - "9000:9000"
+      - "9030:9030"
     environment:
       - _JAVA_OPTIONS=-Xmx512m -Xms256m -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
 

--- a/ui-2/angular.json
+++ b/ui-2/angular.json
@@ -138,6 +138,7 @@
         "serve": {
           "builder": "@angular/build:dev-server",
           "options": {
+            "port": 4300,
             "proxyConfig": "src/proxy.conf.mjs",
             "buildTarget": "ui:build",
             "allowedHosts": ["all"]

--- a/ui-2/src/assets/env.js
+++ b/ui-2/src/assets/env.js
@@ -2,5 +2,5 @@
   window.__env = window.__env || {};
 
   // These are your default local development values
-  window.__env.issuerUrl = 'http://localhost:9000';
+  window.__env.issuerUrl = 'http://localhost:9030';
 })(this);

--- a/ui-2/src/environments/environment.prod.ts
+++ b/ui-2/src/environments/environment.prod.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: true,
-  issuerUrl: (window as any).__env?.issuerUrl || 'http://localhost:9000',
+  issuerUrl: (window as any).__env?.issuerUrl || 'http://localhost:9030',
   redirectUri: window.location.origin + '/en/auth/callback',
   postLogoutRedirectUri: window.location.origin + '/en/login',
 }

--- a/ui-2/src/environments/environment.ts
+++ b/ui-2/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 export const environment = {
   production: false,
-  issuerUrl: (window as any).__env?.issuerUrl || 'http://localhost:9000',
+  issuerUrl: (window as any).__env?.issuerUrl || 'http://localhost:9030',
   redirectUri: window.location.origin + '/auth/callback',
   postLogoutRedirectUri: window.location.origin,
 }

--- a/ui-2/src/proxy.conf.json
+++ b/ui-2/src/proxy.conf.json
@@ -1,11 +1,11 @@
 {
   "/togglz-console*": {
-    "target": "http://localhost:9000",
+    "target": "http://localhost:9030",
     "secure": false,
     "changeOrigin": true
   },
   "/userservice/*": {
-    "target": "http://localhost:9000",
+    "target": "http://localhost:9030",
     "secure": false,
     "changeOrigin": true,
     "pathRewrite": {
@@ -13,12 +13,12 @@
     }
   },
   "/oauth2/*": {
-    "target": "http://localhost:9000",
+    "target": "http://localhost:9030",
     "secure": false,
     "changeOrigin": true
   },
   "/.well-known/*": {
-    "target": "http://localhost:9000",
+    "target": "http://localhost:9030",
     "secure": false,
     "changeOrigin": true
   },

--- a/ui-2/src/proxy.conf.mjs
+++ b/ui-2/src/proxy.conf.mjs
@@ -1,17 +1,17 @@
 export default {
   '/userservice': {
-    target: 'http://localhost:9000',
+    target: 'http://localhost:9030',
     secure: false,
     changeOrigin: true,
     rewrite: (path) => path.replace(/^\/userservice/, ''),
   },
   '/oauth2': {
-    target: 'http://localhost:9000',
+    target: 'http://localhost:9030',
     secure: false,
     changeOrigin: true,
   },
   '/.well-known': {
-    target: 'http://localhost:9000',
+    target: 'http://localhost:9030',
     secure: false,
     changeOrigin: true,
   },

--- a/user-service-2/src/main/docker/Dockerfile
+++ b/user-service-2/src/main/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
 
 ENV SPRING_OUTPUT_ANSI_ENABLED=ALWAYS
 
-EXPOSE 9000
+EXPOSE 9030
 
 # add orcid ca to allow Java application to trust other containers
 ADD src/main/docker/cacerts /opt/java/openjdk/lib/security/cacerts

--- a/user-service-2/src/main/resources/application.yml
+++ b/user-service-2/src/main/resources/application.yml
@@ -36,7 +36,7 @@ spring:
       max-request-size: 30MB
 
 server:
-  port: 9000
+  port: 9030
   forward-headers-strategy: framework
   tomcat:
     accesslog:


### PR DESCRIPTION
Ticket: PD-12930

## Why

To work on the Member Portal locally alongside the Registry, you need both running at once. Today you cannot:

| Port | Member Portal | Registry stack |
|---|---|---|
| 9000 | user service | authorization server |
| 4200 | ui-2 dev server | Registry frontend |

Both pairs bind the same port, so starting one stops the other from starting. The Registry side is the harder one to move — its ports are named by the local reverse-proxy configuration that serves the whole sign-in flow — so this moves ours.

## What changes

- User service: **9000 → 9030**
- ui-2 dev server: **4200 → 4300**

The member and assertion services keep 9010 and 9020; nothing collides there, so nothing moves.

Fourteen lines across nine files: `server.port`, the `EXPOSE` and compose mapping that follow it, the user-service targets in both proxy configs, the issuer URL in `assets/env.js` and the two `environments/*.ts` fallbacks, and an explicit `port` on the `serve` target so `ng serve` and `npm start` agree.


